### PR TITLE
post delete and edit only available for owned items

### DIFF
--- a/src/components/allShared/PostCards/PostCard.js
+++ b/src/components/allShared/PostCards/PostCard.js
@@ -5,6 +5,7 @@ import {
   likePost,
   favoritePost,
   getPostById,
+  deletePost,
 } from "../../../utils/posts";
 
 // Components
@@ -23,6 +24,12 @@ const PostCard = ({ post, userDetails }) => {
     post.userLike
   );
   const [shareBtn, setShareBtn] = useState(true);
+
+  const handleDelete = async () => {
+    // would be nice to have a popup confirmation
+
+    await deletePost(post.id);
+  };
 
   const handleLiked = async () => {
     setLiked(!liked);
@@ -101,8 +108,21 @@ const PostCard = ({ post, userDetails }) => {
             </div>
           </div>
           <div className="postcard-head-right">
-            <i className="fa-solid fa-file-pen"></i>
-            <i className="fa-solid fa-trash"></i>
+            {userDetails.user_id ==
+            post.user_id ? (
+              <i className="fa-solid fa-file-pen"></i>
+            ) : (
+              <></>
+            )}
+            {userDetails.user_id ==
+            post.user_id ? (
+              <i
+                className="fa-solid fa-trash"
+                onClick={handleDelete}
+              ></i>
+            ) : (
+              <></>
+            )}
           </div>
         </div>
 

--- a/src/utils/posts/index.js
+++ b/src/utils/posts/index.js
@@ -156,7 +156,7 @@ export const updatePost = async (
 export const deletePost = async (id) => {
   try {
     const response = await fetch(
-      `${API_URL}/posts/${id}`,
+      `${API_URL}/post/${id}`,
       {
         method: "DELETE",
         headers: {


### PR DESCRIPTION
I have set the edit and delete button in the post card to only show if the user owns the post.
I have wired up delete but it would be nice if it was remove from the display at this point rather than requiring a refresh.

Maybe we need to think about a more dynamic handling of the card display?